### PR TITLE
fix: correct PR comment url in plugin-react-refresh

### DIFF
--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -137,7 +137,7 @@ function reactRefreshPlugin(opts) {
   if (!window.__vite_plugin_react_preamble_installed__) {
     throw new Error(
       "@vitejs/plugin-react-refresh can't detect preamble. Something is wrong. " +
-      "See https://github.com/vitejs/@vitejs/plugin-react-refresh/pull/11#discussion_r430879201"
+      "See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201"
     );
   }
 


### PR DESCRIPTION
fix https://github.com/vitejs/vite/pull/3266#discussion_r626247360

<!-- Thank you for contributing! -->

### Description

Revert the PR comment url from https://github.com/vitejs/vite/pull/3266

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
