### PR TITLE
chore(vite): remove `main` and `module` fields

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -8,8 +8,6 @@
   "bin": {
     "vite": "bin/vite.js"
   },
-  "main": "./dist/node/index.js",
-  "module": "./dist/node/index.js",
   "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
### Description

Since Vite 3 supports Node 14+ and there is already an `exports` field which takes more priority than `main` and `module` so Node will only from `exports` and will never reach to `main` and `module` field entries.

cc @bluwy

<!-- Thank you for contributing! -->

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
